### PR TITLE
fix to implement message ttl on archive queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ pypi:
 	make tag
 
 tag:
-	git tag $$(python -c "from event_consumer.__about__ import __version__; print __version__")
+	git tag $$(python event_consumer/__about__.py)
 	git push --tags
 
 test:

--- a/event_consumer/__about__.py
+++ b/event_consumer/__about__.py
@@ -1,1 +1,5 @@
-__version__ = '1.0.10'
+__version__ = '1.1.0'
+
+
+if __name__ == '__main__':
+    print(__version__)

--- a/event_consumer/conf/defaults.py
+++ b/event_consumer/conf/defaults.py
@@ -27,8 +27,16 @@ MAX_RETRIES = 4  # type: int
 BACKOFF_FUNC = None  # type: Optional[Callable[[int], float]]
 
 RETRY_HEADER = 'x-retry-count'
-# to generate TTL header for archived message (milliseconds)
+
+# to set TTL for archived message (milliseconds)
 ARCHIVE_EXPIRY = int(timedelta(days=24).total_seconds() * 1000)  # type: int
+# max size of archive queue before dropping messages
+ARCHIVE_MAX_LENGTH = 1000000  # type: int
+ARCHIVE_QUEUE_ARGS = {
+    "x-message-ttl": ARCHIVE_EXPIRY,  # Messages dropped after this
+    "x-max-length": ARCHIVE_MAX_LENGTH,  # Maximum size of the queue
+    "x-queue-mode": "lazy",  # Keep messages on disk (reqs. rabbitmq 3.6.0+)
+}
 
 
 USE_DJANGO = False

--- a/event_consumer/handlers.py
+++ b/event_consumer/handlers.py
@@ -249,11 +249,7 @@ class AMQPRetryHandler(object):
                 name='{queue}.archived'.format(queue=queue),
                 exchange=self.exchanges[DEFAULT_EXCHANGE],
                 routing_key='{queue}.archived'.format(queue=queue),
-                queue_arguments={
-                    "x-expires": settings.ARCHIVE_EXPIRY,  # Messages dropped after this
-                    "x-max-length": 1000000,  # Maximum size of the queue
-                    "x-queue-mode": "lazy",  # Keep messages on disk (reqs. rabbitmq 3.6.0+)
-                },
+                queue_arguments=settings.ARCHIVE_QUEUE_ARGS,
                 channel=self.channel,
             )
         except KeyError as key_exc:


### PR DESCRIPTION
From the comments in the code it seems the archive queue was always intended to have a message TTL

However the wrong header was used (`x-expiry`) which instead implemented a different feature (auto delete the queue itself if idle for > x milliseconds)
https://www.rabbitmq.com/ttl.html#queue-ttl

So this implements the intended feature (`x-message-ttl`) and makes the archive queue args fully configurable