### PR TITLE
Apply queue_arguments of message_handler to retry and archive queues

### DIFF
--- a/event_consumer/handlers.py
+++ b/event_consumer/handlers.py
@@ -269,7 +269,8 @@ class AMQPRetryHandler(object):
                 **settings.ARCHIVE_QUEUE_ARGS,
             }
             if archive_queue_arguments.get('x-queue-type') == 'quorum':
-                del archive_queue_arguments['x-message-ttl']
+                'x-message-ttl' in archive_queue_arguments and archive_queue_arguments.pop('x-message-ttl')
+                'x-queue-mode' in archive_queue_arguments and archive_queue_arguments.pop('x-queue-mode')
 
             self.archive_queue = kombu.Queue(
                 name='{queue}.archived'.format(queue=queue),

--- a/event_consumer/handlers.py
+++ b/event_consumer/handlers.py
@@ -257,6 +257,7 @@ class AMQPRetryHandler(object):
                 # N.B. default exchange automatically routes messages to a queue
                 # with the same name as the routing key provided.
                 queue_arguments={
+                    **queue_arguments,
                     "x-dead-letter-exchange": "",
                     "x-dead-letter-routing-key": self.queue,
                 },
@@ -267,7 +268,10 @@ class AMQPRetryHandler(object):
                 name='{queue}.archived'.format(queue=queue),
                 exchange=self.exchanges[DEFAULT_EXCHANGE],
                 routing_key='{queue}.archived'.format(queue=queue),
-                queue_arguments=settings.ARCHIVE_QUEUE_ARGS,
+                queue_arguments={
+                    **queue_arguments,
+                    **settings.ARCHIVE_QUEUE_ARGS,
+                },
                 channel=self.channel,
             )
         except KeyError as key_exc:

--- a/event_consumer/handlers.py
+++ b/event_consumer/handlers.py
@@ -264,14 +264,18 @@ class AMQPRetryHandler(object):
                 channel=self.channel,
             )
 
+            archive_queue_arguments = {
+                **queue_arguments,
+                **settings.ARCHIVE_QUEUE_ARGS,
+            }
+            if archive_queue_arguments.get('x-queue-type') == 'quorum':
+                del archive_queue_arguments['x-message-ttl']
+
             self.archive_queue = kombu.Queue(
                 name='{queue}.archived'.format(queue=queue),
                 exchange=self.exchanges[DEFAULT_EXCHANGE],
                 routing_key='{queue}.archived'.format(queue=queue),
-                queue_arguments={
-                    **queue_arguments,
-                    **settings.ARCHIVE_QUEUE_ARGS,
-                },
+                queue_arguments=archive_queue_arguments,
                 channel=self.channel,
             )
         except KeyError as key_exc:

--- a/event_consumer/handlers.py
+++ b/event_consumer/handlers.py
@@ -172,8 +172,6 @@ class AMQPRetryConsumerStep(bootsteps.StartStopStep):
         for handler in self.handlers:
             handler.declare_queues()
             handler.consumer.consume()
-            if handler.retry_consumer:
-                handler.retry_consumer.consume()
             _logger.debug('AMQPRetryConsumerStep: Started handler: %s', handler)
 
     def stop(self, c):
@@ -314,27 +312,6 @@ class AMQPRetryHandler(object):
 
         self.consumer.qos(prefetch_count=settings.PREFETCH_COUNT)
 
-        if queue_arguments.get('x-queue-type') == 'quorum':
-            self.producer = kombu.Producer(
-                channel,
-                exchange=self.worker_queue.exchange,
-                routing_key=self.worker_queue.routing_key,
-                serializer=settings.SERIALIZER,
-            )
-
-            self.retry_consumer = kombu.Consumer(
-                channel,
-                queues=[self.retry_queue],
-                callbacks=[self.retry_consume],
-                accept=settings.ACCEPT,
-            )
-
-            self.retry_consumer.qos(prefetch_count=settings.PREFETCH_COUNT)
-
-        else:
-            self.retry_consumer = None
-            self.producer = None
-
     def __repr__(self):
         return (
             "AMQPRetryHandler("
@@ -436,33 +413,6 @@ class AMQPRetryHandler(object):
                     "This needs attention. Assuming some kind of error and requeueing the "
                     "message.".format(routing_key=self.routing_key)
                 )
-
-    def retry_consume(self, body, message):
-        def requeue():
-            try:
-                self.producer.publish(
-                    body,
-                    headers=message.headers,
-                    retry=True,
-                )
-
-            except Exception as e:
-                message.requeue()
-                _logger.error(
-                    "Requeue failure:"
-                    "exception='{cls}, {error}'\n"
-                    "{traceback}".format(
-                        cls=e.__class__.__name__,
-                        error=e,
-                        traceback=traceback.format_exc(),
-                    )
-                )
-
-            else:
-                message.ack()
-
-        timer = Timer(int(message.properties.get('expiration', 0)) / 1000, requeue)
-        timer.start()
 
     def retry(self, body, message, reason=''):
         """


### PR DESCRIPTION
When you specify queue_arguments for a message_handler, they should also be reflected on the created retry- and archive-queues.
For example, when you're using RabbitMQ and want to specify a queue as a quorum-queue (`{'x-queue-type': 'quorum'}`), you want that also for the retry and archive queue.